### PR TITLE
Restructure stylizing network to avoid checkerboard pattern in generated image

### DIFF
--- a/style_network.py
+++ b/style_network.py
@@ -23,6 +23,7 @@ class ConvBlock(nn.Module):
         activation: nn.Module = None,
     ):
         super().__init__()
+        
         self.conv = (
             nn.Conv2d(
                 in_channels,
@@ -33,13 +34,15 @@ class ConvBlock(nn.Module):
                 padding_mode="reflect",
             )
             if not up_sampling
-            else nn.ConvTranspose2d(
-                in_channels,
-                out_channels,
-                kernel_size,
-                stride,
-                padding,
-                output_padding,
+            else nn.Sequential(
+                nn.Upsample(scale_factor=stride, mode="bilinear"),
+                nn.Conv2d(
+                    in_channels,
+                    out_channels,
+                    kernel_size,
+                    padding=padding,
+                    padding_mode="reflect"
+                )
             )
         )
         self.norm = nn.InstanceNorm2d(out_channels, affine=True)


### PR DESCRIPTION
We replace `nn.ConvTranspose2d` layers in the upsampling part of the stylizing network with `nn.Upsample + nn.Conv2d` layers which may mitigate the checkerboard pattern in generated images.

Reference:
https://wandb.ai/wandb/common-ml-errors/reports/How-to-avoid-checkerboard-pattern-in-your-generated-images---VmlldzozNTEzNzk